### PR TITLE
Flexible reward drop

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "js-base64": "^3.6.0",
     "notistack": "^1.0.1",
     "react": "^17.0.1",
+    "react-async-hook": "^3.6.2",
     "react-chartist": "^0.14.3",
     "react-dom": "^17.0.1",
     "react-image": "^4.0.3",

--- a/src/components/Stake.tsx
+++ b/src/components/Stake.tsx
@@ -3,7 +3,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import BN from 'bn.js';
 import { useSnackbar } from 'notistack';
 import {
-  Account,
+  Keypair,
   SYSVAR_RENT_PUBKEY,
   SYSVAR_CLOCK_PUBKEY,
 } from '@solana/web3.js';
@@ -98,7 +98,7 @@ export default function Stake() {
       },
     );
 
-    const pendingWithdrawal = new Account();
+    const pendingWithdrawal = new Keypair();
     const tx = await registryClient.rpc.startUnstake(
       new u64(amount),
       isLocked,

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -86,7 +86,7 @@ function RiskBar() {
         }}
       >
         <Typography style={{ fontSize: '14px' }}>
-          Stake is unaudited software. Use at your own risk.
+          Stake V2 is unaudited software. Use at your own risk.
         </Typography>
       </div>
     </div>

--- a/src/components/common/OwnerTokenAccountsSelectV2.tsx
+++ b/src/components/common/OwnerTokenAccountsSelectV2.tsx
@@ -1,0 +1,92 @@
+import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
+import Select from '@material-ui/core/Select';
+import MenuItem from '@material-ui/core/MenuItem';
+import { PublicKey } from '@solana/web3.js';
+import { State as StoreState } from '../../store/reducer';
+import { AccountInfo as TokenAccount, ASSOCIATED_TOKEN_PROGRAM_ID, Token, TOKEN_PROGRAM_ID } from '@solana/spl-token';
+import { useAsync } from 'react-async-hook';
+import { toDisplay } from '../../utils/tokens';
+import { ProgramAccount } from '@project-serum/anchor';
+
+type Props = {
+  style?: any;
+  decimals?: number;
+  variant?: 'outlined' | 'standard';
+  onChange: (from: ProgramAccount<TokenAccount>) => void;
+};
+
+// To avoid painful overall refactor, we introduce V2, which is a drop down showing every owned token mints with an ATA
+export default function OwnedTokenAccountsSelectV2(p: Props) {
+  const { decimals, variant, onChange, style } = p;
+  const ownedTokenAccounts = useSelector((state: StoreState) => {
+    return state.common.ownedTokenAccounts;
+  });
+
+  // Ultimately store should directly deliver that array
+  const ownedATAs = useAsync(async () => {
+    const atas: ProgramAccount<TokenAccount>[] = [];
+    for (const ota of ownedTokenAccounts) {
+      const isATA = ota.publicKey.equals(await Token.getAssociatedTokenAddress(
+          ASSOCIATED_TOKEN_PROGRAM_ID,
+          TOKEN_PROGRAM_ID,
+          ota.account.mint,
+          ota.account.owner,
+      ))
+      if (isATA) {
+        atas.push(ota);
+      }
+    }
+    return atas
+  }, [ownedTokenAccounts]);
+
+  const [fromAccount, setFromAccount] = useState('');
+
+  return (
+    <>
+      <Select
+        style={style}
+        variant={variant}
+        fullWidth
+        value={fromAccount}
+        onChange={e => {
+          const pk = e.target.value as string;
+          setFromAccount(pk);
+          const pubkey = new PublicKey(pk);
+          const ata = ownedATAs
+            .result!
+            .filter(ota => ota.publicKey.equals(pubkey))
+            .pop()!;
+          onChange(ata);
+        }}
+      >
+        {ownedATAs.result?.length === 0 ? (
+          <MenuItem value={''}>No token accounts found</MenuItem>
+        ) : (
+          ownedATAs.result?.map(ownedTokenAccount => {
+            return (
+              <MenuItem value={ownedTokenAccount.publicKey.toString()}>
+                <div
+                  style={{
+                    width: '100%',
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    overflow: 'hidden',
+                  }}
+                >
+                  <div>{`${ownedTokenAccount.publicKey}`}</div>
+                  {decimals && (
+                    <div style={{ float: 'right', color: '#ccc' }}>{`${toDisplay(
+                      ownedTokenAccount.account.amount,
+                      decimals ?? 0,
+                    )}`}</div>
+                  )}
+                </div>
+              </MenuItem>
+            );
+          })
+        )}
+      </Select>
+    </>
+  );
+}

--- a/src/components/rewards/ClaimRewardButton.tsx
+++ b/src/components/rewards/ClaimRewardButton.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useSnackbar } from 'notistack';
 import Button from '@material-ui/core/Button';
 import {
-  Account,
+  Keypair,
   PublicKey,
   SYSVAR_RENT_PUBKEY,
   SYSVAR_CLOCK_PUBKEY,
@@ -50,20 +50,20 @@ export default function ClaimRewardButton(props: ClaimRewardButtonProps) {
   const clickHandler = async (): Promise<void> => {
     notification.withTx(
       snack,
-      `Processing vendor reward ${rli!.vendor!.publicKey.toString()}`,
+      `Processing vendor reward ${rli.vendor.publicKey.toString()}`,
       'Reward processed',
       async () => {
         const vendor = await registryClient.account.rewardVendor.fetch(
-          rli.vendor!.publicKey,
+          rli.vendor.publicKey,
         );
         const _vendorSigner = await vendorSigner(
           registryClient.programId,
           registrar.publicKey,
           rli.vendor!.publicKey,
         );
-        if (rli!.reward.locked) {
-          const vendoredVesting = new Account();
-          const vendoredVestingVault = new Account();
+        if (rli.reward.locked) {
+          const vendoredVesting = new Keypair();
+          const vendoredVestingVault = new Keypair();
           const vendoredVestingSigner = await vestingSigner(
             lockupClient.programId,
             vendoredVesting.publicKey,
@@ -115,7 +115,7 @@ export default function ClaimRewardButton(props: ClaimRewardButtonProps) {
                 ...(await createTokenAccountInstrs(
                   registryClient.provider,
                   vendoredVestingVault.publicKey,
-                  rli.vendor!.account.mint,
+                  rli.vendor.account.mint,
                   vendoredVestingSigner.publicKey,
                 )),
               ],
@@ -151,7 +151,7 @@ export default function ClaimRewardButton(props: ClaimRewardButtonProps) {
                 balances: member!.account.balances,
                 balancesLocked: member!.account.balancesLocked,
 
-                vendor: rli.vendor!.publicKey,
+                vendor: rli.vendor.publicKey,
                 // @ts-ignore
                 vault: vendor.vault,
                 vendorSigner: _vendorSigner.publicKey,

--- a/src/components/rewards/Rewards.tsx
+++ b/src/components/rewards/Rewards.tsx
@@ -79,18 +79,21 @@ export default function Rewards() {
   // All rewards to display.
   const rewards = events
     .map((m: any) => RewardListItemViewModel.fromMessage(ctx, m))
-    .reverse();
+    .reverse()
+    .reduce<RewardListItemViewModel[]>((acc, r) => {
+      if (r !== null) {
+        acc.push(r);
+      }
+      return acc;
+    }, []);
 
   // Next reward to claim.
-  let nextReward = null;
-  if (rewards.filter(r => r === null).length === 0) {
-    nextReward = rewards
-      .filter(r => r!.needsClaim)
-      .sort((a, b) =>
-        a!.cursor < b!.cursor ? -1 : a!.cursor > b!.cursor ? 1 : 0,
-      )
-      .shift();
-  }
+  let nextReward = rewards
+    .filter(r => r.needsClaim)
+    .sort((a, b) =>
+      a.cursor < b.cursor ? -1 : a.cursor > b.cursor ? 1 : 0,
+    )
+    .shift();
 
   return (
     <div style={{ width: '100%', marginTop: '24px' }}>

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -174,7 +174,7 @@ export const initialState: State = {
     isWalletConnected: false,
     walletProvider: 'https://www.sollet.io',
     bootstrapState: BootstrapState.NeedsBootstrap,
-    network: networks.mainnet,
+    network: networks.devnet,
     ownedTokenAccounts: [],
   },
   lockup: {
@@ -182,7 +182,7 @@ export const initialState: State = {
   },
   registry: {
     pendingWithdrawals: null,
-    registrar: networks.mainnet.registrars.srm,
+    registrar: networks.devnet.registrars[0],
   },
   accounts: {},
 };

--- a/src/utils/tokens.tsx
+++ b/src/utils/tokens.tsx
@@ -8,7 +8,6 @@ import React, {
 import BN from 'bn.js';
 import { PublicKey } from '@solana/web3.js';
 import { TokenListProvider, TokenInfo } from '@solana/spl-token-registry';
-import { networks } from '../store/config';
 
 const TokenListContext = React.createContext<TokenListContextValues>({
   tokenMap: new Map(),
@@ -56,11 +55,5 @@ export function toDisplay(amount: BN | number, decimals: number): string {
 }
 
 export function toDisplayLabel(mint: PublicKey): string {
-  let whitelistedMint = Object.keys(networks.mainnet.mints)
-    .filter(label => networks.mainnet.mints[label].equals(mint))
-    .pop();
-  if (whitelistedMint) {
-    return whitelistedMint.toUpperCase();
-  }
   return mint.toString();
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10038,6 +10038,11 @@ react-app-polyfill@^2.0.0:
     regenerator-runtime "^0.13.7"
     whatwg-fetch "^3.4.1"
 
+react-async-hook@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/react-async-hook/-/react-async-hook-3.6.2.tgz#360018e5cd6ecc8841152a79875841b9e49dbdba"
+  integrity sha512-RkwHCJ8V7I6umKZLHneapuTRWf+eO4LOj0qUwUDsSn27jrAOcW6ClbV3x22Z4hVxH9bA0zb7y+ozDJDJ8PnZoA==
+
 react-chartist@^0.14.3:
   version "0.14.4"
   resolved "https://registry.yarnpkg.com/react-chartist/-/react-chartist-0.14.4.tgz#a70bdc78a92a7208973cab4253e177e99dc7bd29"


### PR DESCRIPTION
- Drop reward of any mint: I dropped a reward of the registry mint then another reward of another mint.
- Claim reward, shows both reward vendors, of completely different mint. It doesn't look super obvious on the UI when I already claimed a reward, is that normal?
![Screenshot from 2021-07-15 19-27-02](https://user-images.githubusercontent.com/8245419/125764726-63d3d624-32cc-4951-882c-8fcb9bcbd72e.png)

I planned to do a devnet deployment for mercurial but RPC is sick, so it will wait...